### PR TITLE
Release v1.5.1.2: GUI Polish & Taskbar Icon Fix

### DIFF
--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -417,7 +417,7 @@ def run_audioctl_interactive(args_list, prompt_patterns, expect_ok=True):
 class AudioGUI:
     def __init__(self, root):
         self.root = root
-        self.root.title("Mr5niper's Audio Control  v1.5.1.1  02-22-2026")
+        self.root.title("Mr5niper's Audio Control  v1.5.1.2  02-24-2026")
         # Style and theme
         style = ttk.Style(self.root)
         try:
@@ -2449,4 +2449,5 @@ def launch_gui():
         _log_exc("MAINLOOP EXCEPTION")
     _log("launch_gui: mainloop exited")
     return 0
+
 

--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -2396,7 +2396,9 @@ def launch_gui():
     root = tk.Tk()
     try:
         if sys.platform.startswith("win"):
-            root.iconbitmap(resource_path("audio.ico"))
+            # Use 'default=' to apply the icon to the entire application instance,
+            # overriding the inherited console/shim icon in the Taskbar.
+            root.iconbitmap(default=resource_path("audio.ico"))
     except Exception:
         pass
     gui = AudioGUI(root)
@@ -2447,3 +2449,4 @@ def launch_gui():
         _log_exc("MAINLOOP EXCEPTION")
     _log("launch_gui: mainloop exited")
     return 0
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,19 @@
 # AUDIOCTL.PY CHANGELOG
 
 
-## v1.5.1.1 - [current]
+## v1.5.1.2 - [current]
+
+### GUI Polish & Usability
+
+*   **Taskbar Icon Fix:** Resolved an issue where the application icon reverted to a generic "feather" or console icon when running as a non-admin frozen executable.
+    *   *Fix:* Applied the icon as the application default (`root.iconbitmap(default=...)`) to override the PyInstaller bootloader identity 011 audioctl/gui.py.
+*   **Snappy Volume Slider:** The volume dialog slider now responds instantly to clicks (jump-to-position) and supports immediate dragging.
+    *   Replaces the default incremental "step" behavior with custom mouse event bindings for a modern slider feel.
+*   **Visual Clean-up:** Removed the dotted "focus ring" (ghost box) from the selected device row in the main list for a cleaner look.
+
+---
+
+## v1.5.1.1
 
 ### GUI Features
 - **Embedded Console Mirror:** Added a scrollable text console to the main window that mirrors `stdout`/`stderr` in real-time [10].
@@ -558,5 +570,6 @@ Date: 2026-01-19
 - **Basic Enumeration:** Listed playback (Render) and recording (Capture) devices using `IMMDeviceEnumerator` with `DEVICE_STATE_ACTIVE` only.
 - **“Listen” Toggle (Admin):** Initial registry-based enable/disable of “Listen to this device” for capture endpoints (admin required).
 - **Admin Check:** `is_admin` helper added to warn when elevation is required.
+
 
 

--- a/docs/ENGINEERING_GUIDE.md
+++ b/docs/ENGINEERING_GUIDE.md
@@ -1,8 +1,8 @@
-# ENGINEERING GUIDE (v1.5.1.1)
+# ENGINEERING GUIDE (v1.5.1.2)
 **audioctl - Windows Audio Control CLI + GUI (PyInstaller EXE)**
 **Audience:** Engineers debugging, maintaining, or extending the codebase  
 **Platforms:** Windows 10/11  
-**Version:** 1.5.1.1  
+**Version:** 1.5.1.2  
 **Build contract:** **Python 3.13.12 required**, **PyInstaller required**
 
 This document is intentionally **not** a usage manual. The README covers commands, examples, and screenshots.  
@@ -36,7 +36,7 @@ The *real* entrypoint is always:
 - `audioctl.cli.main()`
 
 ### 1.4 Build artifacts / metadata
-- Windows version info comes from `version.txt` (filevers/prodvers 1.5.1.1).
+- Windows version info comes from `version.txt` (filevers/prodvers 1.5.1.2).
 - Icon `audio.ico` is embedded and also shipped as data.
 
 ---
@@ -59,7 +59,7 @@ Logic is strictly partitioned to prevent COM threading deadlock and maintain JSO
 
 * **audioctl/cli.py**
     This module manages argument parsing, exit code logic, and JSON serialization. It is the "backend" for the GUI.
-    *   **New in v1.5.1.1:** Handles conditional JSON payload generation for `listen` commands to preserve backward compatibility while exposing routing info.
+    *   **New in v1.5.1.2:** Handles conditional JSON payload generation for `listen` commands to preserve backward compatibility while exposing routing info.
 
 * **audioctl/gui.py**
     This Tkinter interface operates as a pure client that executes the CLI via subprocess and parses JSON output.
@@ -97,7 +97,7 @@ The GUI depends on these commands and expects these keys (minimum):
 - `list --json` → `{"devices":[...]}` and devices include `id,name,flow,state,isDefault` plus `guiIndex` tagging behavior.
 - `get-device-state` → includes `volume,muted,listenEnabled,enhancementsEnabled,availableFX`.
 - `enhancements --list-fx --json` shape (GUI uses it for menus in some paths).
-- `listen` payload contract (v1.5.1.1 update):
+- `listen` payload contract (v1.5.1.2 update):
     - Standard keys: `id`, `name`, `enabled`.
     - **Conditional keys:** `playbackTargetId` and `playbackTargetName` are ONLY present if requested via arguments (`--playback-target-id` etc).
     - If you add keys unconditionally, you risk breaking parsers expecting the legacy shape.

--- a/docs/README.md
+++ b/docs/README.md
@@ -713,7 +713,8 @@ Use `.\audioctl.exe wait` to block until a device becomes active (appears) or un
     <img width="98" height="130" alt="image" src="https://github.com/user-attachments/assets/46adf78b-c222-4aaa-8e5d-0bd5bcc5b9bb" />
   <br>
   
-<img width="1980" height="545" alt="image" src="https://github.com/user-attachments/assets/a61c9f2e-4d02-418e-a71c-7b6637594e70" />
+<img width="1980" height="754" alt="image" src="https://github.com/user-attachments/assets/d1db39f2-99a2-4264-8a44-973671d364a1" />
+
 <br>
 
 ### Features
@@ -748,14 +749,18 @@ Use `.\audioctl.exe wait` to block until a device becomes active (appears) or un
 
 ### Print CLI Commands
 - Enable **“Print CLI commands”** in the top bar.  
-  Every GUI action will print the equivalent `audioctl.exe` command to the console (useful for learning the CLI and scripting).
-
-<img width="306" height="89" alt="image" src="https://github.com/user-attachments/assets/b68eed8f-3830-469e-b95f-be907cd9b523" />
+  Every GUI action will print the equivalent `audioctl.exe` command to the console in blue font(useful for learning the CLI and scripting).
+    
+    <img width="320" height="85" alt="image" src="https://github.com/user-attachments/assets/f4914104-eefe-4c51-b8c7-5261991c1867" />
     <br>
     <br>
 
-<img width="1602" height="283" alt="image" src="https://github.com/user-attachments/assets/05879549-9e60-4c52-834d-d3453a5fc0fd" />
+    <img width="1602" height="184" alt="image" src="https://github.com/user-attachments/assets/a97b6ecb-ffa1-4847-83a8-4735230c1e85" />
 
+- Highlight a command, right-click, and copy it directly from the console:
+    
+    <img width="820" height="145" alt="image" src="https://github.com/user-attachments/assets/c3b7a1dc-b427-4ca7-9ae5-0dc517b0f5d2" />
+    <br>
 
 ### Refresh Devices
 - Click **"Refresh"** or press `F5`.

--- a/docs/VENDOR_TOGGLES.md
+++ b/docs/VENDOR_TOGGLES.md
@@ -1,12 +1,12 @@
-# Vendor Toggles Configuration Guide (v1.5.1.1)
+# Vendor Toggles Configuration Guide (v1.5.1.2)
 This guide explains **vendor_toggles.ini**: the database that teaches **audioctl** how to reliably toggle **Audio Enhancements (SysFX)** and individual **FX effects** on specific Windows audio endpoints.
 
 Because vendors implement enhancements/effects differently (and sometimes don’t honor Windows’ generic SysFX switches), audioctl uses **learned registry-write rules** stored in this INI.
 
-This document reflects the behavior of `audioctl/vendor_db.py` in **v1.5.1.1**.
+This document reflects the behavior of `audioctl/vendor_db.py` in **v1.5.1.2**.
 --------------------------------------------------------------------------------
 
-## 1) What is vendor_toggles.ini? (v1.5.1.1)
+## 1) What is vendor_toggles.ini? (v1.5.1.2)
 
 `vendor_toggles.ini` is audioctl’s **INI-backed vendor toggle rule database**. It stores the learned rules that tell audioctl **exactly which MMDevices registry values to read and write** to control:
 
@@ -20,8 +20,8 @@ What’s in the file:
   - legacy single-DWORD effects, or
   - multi-write effects (several values, possibly mixing `REG_DWORD`, `REG_SZ`, `REG_BINARY`)
 
-### v1.5.1.1 nuance: shared rules + “registry truth” discovery
-In v1.5.1.1, the INI is best thought of as a **rule library**, not just “a list of devices”.
+### v1.5.1.2 nuance: shared rules + “registry truth” discovery
+In v1.5.1.2, the INI is best thought of as a **rule library**, not just “a list of devices”.
 
 audioctl uses **live registry signature matching (“registry truth”)** to decide applicability:
 
@@ -40,7 +40,7 @@ So the file describes:
 
 --------------------------------------------------------------------------------
 
-## 2) Default location and permissions (v1.5.1.1)
+## 2) Default location and permissions (v1.5.1.2)
 **`vendor_toggles.ini` ships inside the project’s `dist/` folder**, so when you build/package the app, the INI ends up **next to the generated `audioctl.exe`**.
 
 So the effective default is:
@@ -71,7 +71,7 @@ This means:
 ## 3) Do I need this file?
 Yes, if you want audioctl to toggle Enhancements or FX reliably.
 
-In v1.5.1.1 the runtime policy is **vendor-only**:
+In v1.5.1.2 the runtime policy is **vendor-only**:
 - If audioctl cannot find a matching vendor rule in `vendor_toggles.ini`, it returns:
   - `no-vendor-method`
 
@@ -98,13 +98,13 @@ For a given endpoint GUID, audioctl targets MMDevices keys:
 `HKCU/HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\{Render|Capture}\{GUID}\{FxProperties|Properties}`
 
 Important:
-- v1.5.1.1 records and uses the learned **subkey**:
+- v1.5.1.2 records and uses the learned **subkey**:
   - `FxProperties` or `Properties`
 - audioctl tries hard not to “guess” at runtime; it reads/writes exactly the learned location.
 
 --------------------------------------------------------------------------------
 
-## 6) New / notable behavior in v1.5.1.1 (what changed vs older guides)
+## 6) New / notable behavior in v1.5.1.2 (what changed vs older guides)
 
 ### 6.1 Vendor-only runtime (“no Windows fallback”)
 `_apply_enhancements()` is vendor-only:
@@ -206,10 +206,10 @@ Field meanings:
   - Which endpoint flows this entry can apply to: `Render`, `Capture`, or both
 - `subkey`
   - Learned location: `FxProperties` or `Properties`
-  - v1.5.1.1 reads/writes exactly this learned scope
+  - v1.5.1.2 reads/writes exactly this learned scope
 - `devices`
   - A list of endpoint GUIDs associated with this entry (used for candidate filtering in some paths)
-  - NOTE: v1.5.1.1 also uses registry signature truth; support/apply ultimately depends on signature match for the endpoint
+  - NOTE: v1.5.1.2 also uses registry signature truth; support/apply ultimately depends on signature match for the endpoint
 
 Runtime rule (MAIN):
 - Support is determined by whether a MAIN entry’s **registry signature matches** the endpoint now.
@@ -235,7 +235,7 @@ notes = Some devices
 devices = {guid-a},{guid-b}
 ```
 
-Key points (v1.5.1.1):
+Key points (v1.5.1.2):
 - Legacy FX toggling is treated similarly to MAIN toggling for writing:
   - it writes a single DWORD value
 - Before applying a legacy FX, audioctl performs a *truth check*:
@@ -302,12 +302,12 @@ guids_1a2b3c4d = {guid-a},{guid-b}
 ### 10.1 Section-level `devices = ...` (FX bucket membership)
 For FX sections, `devices = ...` is the “bucket membership” union list:
 - used as a fast association list
-- however, v1.5.1.1 can also discover FX by signature even if the GUID is not listed
+- however, v1.5.1.2 can also discover FX by signature even if the GUID is not listed
 
 ### 10.2 Per-write scoping: `write{i}_devices` semantics (important)
 Each write block can optionally define its own device list.
 
-Semantics in v1.5.1.1 loader:
+Semantics in v1.5.1.2 loader:
 - Missing `write{i}_devices` key:
   - `devices: None` in memory
   - Means “universal within this FX bucket”
@@ -317,7 +317,7 @@ Semantics in v1.5.1.1 loader:
 - Present with list:
   - applies only to those GUIDs
 
-Important runtime nuance in v1.5.1.1:
+Important runtime nuance in v1.5.1.2:
 - For *matching/verification/reading* multi-write FX signatures, code intentionally ignores per-write gating:
   - it checks whether the registry values match the INI signatures for this endpoint
 - For *applying* multi-write writes, it also intentionally ignores per-write gating:
@@ -355,7 +355,7 @@ Multi-write FX uses `_read_decider_state()`:
 
 Config fields:
 - `decider_index`
-  - Stored/parsed, but the v1.5.1.1 readback logic primarily uses quorum + best-signal scoring.
+  - Stored/parsed, but the v1.5.1.2 readback logic primarily uses quorum + best-signal scoring.
 - `quorum_threshold`
   - Default: 0.60
   - Clamped internally to [0.50, 0.95]
@@ -454,13 +454,13 @@ audioctl enhancements --id "{ENDPOINT-ID}" --delete-fx "BassBoost"
 
 --------------------------------------------------------------------------------
 
-## 16) Best practices (v1.5.1.1 behavior-aware)
+## 16) Best practices (v1.5.1.2 behavior-aware)
 - Learn MAIN Enhancements first if your vendor effects depend on the global switch.
 - Run elevated if HKLM writes are required (common for some vendor drivers).
 - Keep effect names stable and human-friendly (`BassBoost`, `Loudness`, etc.).
 - Prefer not to hand-edit multi-write payloads unless you understand the driver behavior:
   - incorrect types/payloads can cause mismatched signatures, failed writes, or unstable state reads.
-- If a driver uses `Properties` instead of `FxProperties`, ensure `subkey = Properties` is recorded; v1.5.1.1 will respect it.
+- If a driver uses `Properties` instead of `FxProperties`, ensure `subkey = Properties` is recorded; v1.5.1.2 will respect it.
 
 --------------------------------------------------------------------------------
 

--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(1, 5, 1, 1),
-    prodvers=(1, 5, 1, 1),
+    filevers=(1, 5, 1, 2),
+    prodvers=(1, 5, 1, 2),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -14,16 +14,17 @@ VSVersionInfo(
       StringTable('040904E4', [
           StringStruct('CompanyName', 'Mr5niper5oft'),
           StringStruct('FileDescription', 'Windows Audio Control CLI'),
-          StringStruct('FileVersion', '1.5.1.1'),
+          StringStruct('FileVersion', '1.5.1.2'),
           StringStruct('InternalName', 'audioctl'),
           StringStruct('LegalCopyright', 'Copyright (c) 2025 Mr5niper5oft'),
           StringStruct('OriginalFilename', 'audioctl.exe'),
           StringStruct('ProductName', 'Windows Audio Control CLI'),
-          StringStruct('ProductVersion', '1.5.1.1'),
+          StringStruct('ProductVersion', '1.5.1.2'),
         ]
       )
     ]),
     VarFileInfo([VarStruct('Translation', [1033, 1252])])
   ]
 )
+
 


### PR DESCRIPTION
This PR merges `develop` into `main`, bringing the application to version **v1.5.1.2**. This release focuses on GUI polish, specifically resolving visual annoyances and fixing a persistent issue with the application icon in the Windows Taskbar.

### Release Notes

#### Bug Fixes: Taskbar Icon Identity
Resolved the "Feather Icon" issue where the Taskbar displayed a generic Python/Console icon when running the frozen executable without Admin privileges.
*   **Technical:** Updated `audioctl/gui.py` to use `root.iconbitmap(default=...)`. This forces the Tcl/Tk application instance to override the icon inherited from the PyInstaller bootloader.

#### GUI & Usability Polish
*   **Snappy Volume Slider:** Overrode default `ttk.Scale` behavior. The slider now jumps instantly to the click position and supports immediate dragging via custom `<Button-1>` and `<B1-Motion>` bindings.
*   **Visual Cleanup:** Removed the Windows-native dotted "focus ring" (ghost box) from the device list by modifying the `Treeview.Item` layout style.

#### Documentation & Versioning
*   Bumped version headers to **1.5.1.2**.
*   Updated README images and clarified text regarding "Print CLI commands".

### Verification
*   Verified Taskbar icon persists across standard and Admin execution modes.
*   Verified volume slider "jump-to-click" and "slide" behavior.
*   Verified removal of dotted outline on selected Treeview rows.