### PR TITLE
Enhance CLI output in the GUI console and update to v1.5.4.0

### DIFF
--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -1315,10 +1315,16 @@ class AudioGUI:
         try:
             from .logging_setup import _log, _dbg
             _dbg(f"GUI: on_set_default for id={d['id']} flow={d['flow']}")
+            
             if d["flow"] == "Render":
                 args = ["set-default", "--playback-id", d["id"], "--playback-role", "all"]
+                # Create friendly version for display
+                display_args = ["set-default", "--playback-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--playback-role", "all"]
             else:
                 args = ["set-default", "--recording-id", d["id"], "--recording-role", "all"]
+                # Create friendly version for display
+                display_args = ["set-default", "--recording-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--playback-role", "all"]
+            
             if not is_admin():
                 if not messagebox.askyesno(
                     "Administrator recommended",
@@ -1326,12 +1332,18 @@ class AudioGUI:
                 ):
                     _log(f"GUI action: set-default cancelled id={d['id']} name={d['name']}")
                     return
+            
             _log(f"GUI action: set-default start via CLI id={d['id']} name={d['name']} flow={d['flow']} roles=all")
+            
+            # Use original args (ID) for the actual functional change
             data = run_audioctl(args, capture_json=True, expect_ok=True)
+            
+            # Use display_args (Name/Index) for the user-facing print
             cmd_str = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
             self.maybe_print_cli(cmd_str)
+            
             self.set_status(f"Set default ({d['flow']}) device: {d['name']} (all roles)")
             self.refresh_devices()
             _log(f"GUI action: set-default success via CLI id={d['id']} name={d['name']} flow={d['flow']}")
@@ -1355,6 +1367,8 @@ class AudioGUI:
                 _log(f"GUI action: set-volume cancelled id={d['id']} name={d['name']}")
                 return
             _log(f"GUI action: set-volume start via CLI id={d['id']} name={d['name']} flow={d['flow']} level={level}")
+            
+            # Functional Command (ID)
             args = [
                 "set-volume",
                 "--id", d["id"],
@@ -1362,11 +1376,24 @@ class AudioGUI:
                 "--level", str(level),
                 "--json",
             ]
+
+            # Display Command (Name/Index)
+            display_args = [
+                "set-volume",
+                "--name", f'"{d["name"]}"',
+                "--flow", d["flow"],
+                "--index", str(d["_index"]),
+                "--level", str(level),
+            ]
+
             rc, out, err = run_audioctl(args, capture_json=False, expect_ok=False)
+
+            # Generate the string from display_args instead of args
             cmd_str = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
             self.maybe_print_cli(cmd_str)
+
             if rc == 0:
                 try:
                     info = json.loads(out or "{}")
@@ -1410,8 +1437,11 @@ class AudioGUI:
                     muted = data.get("muted", None)
             except Exception:
                 muted = None
+            
             # Decide target action
             target_flag = "--unmute" if muted is True else "--mute"
+            
+            # Functional Command (ID)
             args = [
                 "set-volume",
                 "--id", d["id"],
@@ -1419,11 +1449,24 @@ class AudioGUI:
                 target_flag,
                 "--json",
             ]
+
+            # Display Command (Name/Index)
+            display_args = [
+                "set-volume",
+                "--name", f'"{d["name"]}"',
+                "--flow", d["flow"],
+                "--index", str(d["_index"]),
+                target_flag,
+            ]
+
             rc, out, err = run_audioctl(args, capture_json=False, expect_ok=False)
+
+            # Update Print CLI to use the Friendly version
             cmd_str = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
             self.maybe_print_cli(cmd_str)
+
             if rc == 0:
                 try:
                     info = json.loads(out or "{}")
@@ -1485,12 +1528,21 @@ class AudioGUI:
                     "Yes = Enable\nNo = Disable"
                 )
                 enable = bool(choice)
+
+            # Functional Command (ID)
             args = ["listen", "--id", d["id"], "--enable" if enable else "--disable", "--json"]
+
+            # Display Command (Name/Index)
+            display_args = ["listen", "--name", f'"{d["name"]}"', "--index", str(d["_index"]), "--enable" if enable else "--disable"]
+
             rc, out, err = run_audioctl(args, capture_json=False, expect_ok=False)
-            cmd = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+
+            # Update Print CLI to use the Friendly version
+            cmd_str = format_audioctl_cmd_for_display(
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
-            self.maybe_print_cli(cmd)
+            self.maybe_print_cli(cmd_str)
+
             if rc == 0:
                 try:
                     info = json.loads(out or "{}")
@@ -1556,17 +1608,32 @@ class AudioGUI:
                     "Yes = Enable\nNo = Disable"
                 )
                 enable = bool(choice)
+
+            # Functional Command (ID)
             args = [
                 "enhancements",
                 "--id", d["id"],
                 "--flow", d["flow"],
                 "--enable" if enable else "--disable",
             ]
+
+            # Display Command (Name/Index)
+            display_args = [
+                "enhancements",
+                "--name", f'"{d["name"]}"',
+                "--flow", d["flow"],
+                "--index", str(d["_index"]),
+                "--enable" if enable else "--disable",
+            ]
+
             data = run_audioctl(args, capture_json=True, expect_ok=False)
+
+            # Generate string from display_args for the user-facing print
             cmd_str = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
             self.maybe_print_cli(cmd_str)
+
             enh = data.get("enhancementsSet")
             if enh:
                 state = enh.get("enabled", enable)
@@ -2290,6 +2357,8 @@ class AudioGUI:
                 enable = False
             else:
                 enable = True
+            
+            # Functional Command (ID)
             args = [
                 "enhancements",
                 "--id", d["id"],
@@ -2297,11 +2366,25 @@ class AudioGUI:
                 "--enable-fx" if enable else "--disable-fx",
                 fx_name,
             ]
+
+            # Display Command (Name/Index)
+            display_args = [
+                "enhancements",
+                "--name", f'"{d["name"]}"',
+                "--flow", d["flow"],
+                "--index", str(d["_index"]),
+                "--enable-fx" if enable else "--disable-fx",
+                fx_name,
+            ]
+
             data = run_audioctl(args, capture_json=True, expect_ok=False)
+            
+            # Update Print CLI to use the Friendly version
             cmd_str = format_audioctl_cmd_for_display(
-                args, frozen=getattr(sys, "frozen", False), cross_shell=True
+                display_args, frozen=getattr(sys, "frozen", False), cross_shell=True
             )
             self.maybe_print_cli(cmd_str)
+
             fx_set = data.get("fxSet")
             if fx_set:
                 state = fx_set.get("enabled", enable)

--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -1319,11 +1319,11 @@ class AudioGUI:
             if d["flow"] == "Render":
                 args = ["set-default", "--playback-id", d["id"], "--playback-role", "all"]
                 # Create friendly version for display
-                display_args = ["set-default", "--playback-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--playback-role", "all"]
+                display_args = ["set-default", "--playback-name", d["name"], "--index", str(d["_index"]), "--playback-role", "all"]
             else:
                 args = ["set-default", "--recording-id", d["id"], "--recording-role", "all"]
                 # Verify this line uses --recording-name and --recording-role
-                display_args = ["set-default", "--recording-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--recording-role", "all"]
+                display_args = ["set-default", "--recording-name", d["name"], "--index", str(d["_index"]), "--recording-role", "all"]
             
             if not is_admin():
                 if not messagebox.askyesno(
@@ -1380,7 +1380,7 @@ class AudioGUI:
             # Display Command (Name/Index)
             display_args = [
                 "set-volume",
-                "--name", f'"{d["name"]}"',
+                "--name", d["name"],
                 "--flow", d["flow"],
                 "--index", str(d["_index"]),
                 "--level", str(level),
@@ -1453,7 +1453,7 @@ class AudioGUI:
             # Display Command (Name/Index)
             display_args = [
                 "set-volume",
-                "--name", f'"{d["name"]}"',
+                "--name", d["name"],
                 "--flow", d["flow"],
                 "--index", str(d["_index"]),
                 target_flag,
@@ -1533,7 +1533,7 @@ class AudioGUI:
             args = ["listen", "--id", d["id"], "--enable" if enable else "--disable", "--json"]
 
             # Display Command (Name/Index)
-            display_args = ["listen", "--name", f'"{d["name"]}"', "--index", str(d["_index"]), "--enable" if enable else "--disable"]
+            display_args = ["listen", "--name", d["name"], "--index", str(d["_index"]), "--enable" if enable else "--disable"]
 
             rc, out, err = run_audioctl(args, capture_json=False, expect_ok=False)
 
@@ -1620,7 +1620,7 @@ class AudioGUI:
             # Display Command (Name/Index)
             display_args = [
                 "enhancements",
-                "--name", f'"{d["name"]}"',
+                "--name", d["name"],
                 "--flow", d["flow"],
                 "--index", str(d["_index"]),
                 "--enable" if enable else "--disable",
@@ -2370,7 +2370,7 @@ class AudioGUI:
             # Display Command (Name/Index)
             display_args = [
                 "enhancements",
-                "--name", f'"{d["name"]}"',
+                "--name", d["name"],
                 "--flow", d["flow"],
                 "--index", str(d["_index"]),
                 "--enable-fx" if enable else "--disable-fx",

--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -1322,8 +1322,8 @@ class AudioGUI:
                 display_args = ["set-default", "--playback-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--playback-role", "all"]
             else:
                 args = ["set-default", "--recording-id", d["id"], "--recording-role", "all"]
-                # Create friendly version for display
-                display_args = ["set-default", "--recording-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--playback-role", "all"]
+                # Verify this line uses --recording-name and --recording-role
+                display_args = ["set-default", "--recording-name", f'"{d["name"]}"', "--index", str(d["_index"]), "--recording-role", "all"]
             
             if not is_admin():
                 if not messagebox.askyesno(

--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -419,7 +419,7 @@ def run_audioctl_interactive(args_list, prompt_patterns, expect_ok=True):
 class AudioGUI:
     def __init__(self, root):
         self.root = root
-        self.root.title("Mr5niper's Audio Control  v1.5.3.0  04-05-2026")
+        self.root.title("Mr5niper's Audio Control  v1.5.4.0  04-29-2026")
         # Style and theme
         style = ttk.Style(self.root)
         try:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # AUDIOCTL.PY CHANGELOG
+## v1.5.4.0 - [current]
 
-## v1.5.3.0 - [current]
+### GUI & CLI Mirroring
+Friendly Command Echoing: Updated the "Print CLI commands" feature to use device Names and Indices (matching the GUI list order) instead of internal GUID strings. This ensures echoed commands are human-readable and can be copy-pasted directly into a terminal.
+
+---
+
+## v1.5.3.0
 
 ### Vendor Engine Upgrades
 - **Profile-Aware Universal Spoofing:** Upgraded the multi-write FX engine to intelligently group writes into distinct device "profiles". When a new device is discovered, the engine scores the live registry to find the best-fit profile and strictly applies only the relevant writes.

--- a/docs/ENGINEERING_GUIDE.md
+++ b/docs/ENGINEERING_GUIDE.md
@@ -1,8 +1,8 @@
-# ENGINEERING GUIDE (v1.5.3.0)
+# ENGINEERING GUIDE (v1.5.4.0)
 **audioctl - Windows Audio Control CLI + GUI (PyInstaller EXE)**
 **Audience:** Engineers debugging, maintaining, or extending the codebase  
 **Platforms:** Windows 10/11  
-**Version:** 1.5.3.0 
+**Version:** 1.5.4.0 
 **Build contract:** **Python 3.13.12 required**, **PyInstaller required**
 
 This document is intentionally **not** a usage manual. The README covers commands, examples, and screenshots.  
@@ -36,7 +36,7 @@ The *real* entrypoint is always:
 - `audioctl.cli.main()`
 
 ### 1.4 Build artifacts / metadata
-- Windows version info comes from `version.txt` (filevers/prodvers 1.5.3.0).
+- Windows version info comes from version.txt (filevers/prodvers 1.5.4.0).
 - Icon `audio.ico` is embedded and also shipped as data.
 
 ---
@@ -59,10 +59,11 @@ Logic is strictly partitioned to prevent COM threading deadlock and maintain JSO
 
 * **audioctl/cli.py**
     This module manages argument parsing, exit code logic, and JSON serialization. It is the "backend" for the GUI.
-    *   **New in v1.5.1.2:** Handles conditional JSON payload generation for `listen` commands to preserve backward compatibility while exposing routing info.
+    *   **New Starting in v1.5.1.2:** Handles conditional JSON payload generation for `listen` commands to preserve backward compatibility while exposing routing info.
 
 * **audioctl/gui.py**
-    This Tkinter interface operates as a pure client that executes the CLI via subprocess and parses JSON output.
+  This Tkinter interface operates as a pure client that executes the CLI via subprocess and parses JSON output.
+    *   **Update v1.5.4.0:** Updated "Print CLI commands" logic to use device Names and Indices for echoed text to improve human-readability.
     *   **Console Mirror:** Implements a `Tee` to redirect stdout/stderr into an embedded `ScrolledText` widget.
     *   **Window Logic:** Manages auto-minimization of the external console on launch to reduce clutter.
 
@@ -97,7 +98,7 @@ The GUI depends on these commands and expects these keys (minimum):
 - `list --json` → `{"devices":[...]}` and devices include `id,name,flow,state,isDefault` plus `guiIndex` tagging behavior.
 - `get-device-state` → includes `volume,muted,listenEnabled,enhancementsEnabled,availableFX`.
 - `enhancements --list-fx --json` shape (GUI uses it for menus in some paths).
-- `listen` payload contract (v1.5.1.2 update):
+- `listen` payload contract:
     - Standard keys: `id`, `name`, `enabled`.
     - **Conditional keys:** `playbackTargetId` and `playbackTargetName` are ONLY present if requested via arguments (`--playback-target-id` etc).
     - If you add keys unconditionally, you risk breaking parsers expecting the legacy shape.
@@ -289,7 +290,7 @@ Drivers may store toggles under either:
 - PROPERTYKEY fmtid `{E4870E26-3CC5-4CD2-BA46-CA0A9A70ED04}`, pid `2`
 - Semantics: 0 enhancements ON, 1 enhancements OFF
 
-In v1.5.x:
+In v1.5.x.x:
 - used for diagnostics/discovery/learn tooling
 - **not** used as runtime toggle mechanism (runtime is vendor-only)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -713,7 +713,8 @@ Use `.\audioctl.exe wait` to block until a device becomes active (appears) or un
     <img width="98" height="130" alt="image" src="https://github.com/user-attachments/assets/46adf78b-c222-4aaa-8e5d-0bd5bcc5b9bb" />
   <br>
   
-<img width="1980" height="754" alt="image" src="https://github.com/user-attachments/assets/d1db39f2-99a2-4264-8a44-973671d364a1" />
+<img width="1980" height="754" alt="image" src="https://github.com/user-attachments/assets/c206ea76-0efe-4e95-9b63-e76385ca0f3d" />
+
 
 <br>
 
@@ -749,18 +750,18 @@ Use `.\audioctl.exe wait` to block until a device becomes active (appears) or un
 
 ### Print CLI Commands
 - Enable **“Print CLI commands”** in the top bar.  
-  Every GUI action will print the equivalent `audioctl.exe` command to the console in blue font(useful for learning the CLI and scripting).
     
-    <img width="320" height="85" alt="image" src="https://github.com/user-attachments/assets/f4914104-eefe-4c51-b8c7-5261991c1867" />
-    <br>
-    <br>
+    <img width="320" height="85" alt="image" src="https://github.com/user-attachments/assets/f062528a-3729-4639-8a35-f593d894da33" />
 
-    <img width="1602" height="184" alt="image" src="https://github.com/user-attachments/assets/a97b6ecb-ffa1-4847-83a8-4735230c1e85" />
+- Every GUI action will print the equivalent `audioctl.exe` command to the console in blue font
+  <br>(useful for learning the CLI and scripting).
+
+    <img width="1602" height="184" alt="image" src="https://github.com/user-attachments/assets/892334e9-6409-4eed-941b-7659fbd010b1" />
+
 
 - Highlight a command, right-click, and copy it directly from the console:
     
-    <img width="820" height="145" alt="image" src="https://github.com/user-attachments/assets/c3b7a1dc-b427-4ca7-9ae5-0dc517b0f5d2" />
-    <br>
+    <img width="820" height="131" alt="image" src="https://github.com/user-attachments/assets/1d64ee6f-7c83-4649-8ee3-b59ba0a880a2" />
 
 ### Refresh Devices
 - Click **"Refresh"** or press `F5`.
@@ -773,11 +774,20 @@ Use `.\audioctl.exe wait` to block until a device becomes active (appears) or un
 ---
 
 ## Credits
-This project uses:
-- pycaw - <https://github.com/AndreMiras/pycaw>  
-- comtypes - <https://github.com/enthought/comtypes>  
+### Mr5niper: 
+<https://github.com/Mr5niper>
 
-Windows GUIDs and PROPERTYKEY constants are Microsoft API identifiers and do not require attribution.
+Lead Developer.  Performed the original research and reverse-engineering of the Windows registry-based "Learn" logic for Enhancements and FX.  Implemented critical stability shims for comtypes and pycaw to resolve apartment-lifetime issues, prevents shutdown crashes, and ensures thread-safe COM interactions.  Designed the CLI-to-GUI architecture.<br>
+### Pycaw: 
+<https://github.com/AndreMiras/pycaw>
+
+Used for the underlying Windows Core Audio API endpoint wrappers.<br>
+### comtypes: 
+<https://github.com/enthought/comtypes>
+
+Used for COM interface handling and PROPVARIANT support.<br>
+### The Windows Audio Community:
+For historical research into the undocumented IPolicyConfig and IPolicyConfigFx interfaces used for default endpoint selection.
 
 ---
 

--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(1, 5, 3, 0),
-    prodvers=(1, 5, 3, 0),
+    filevers=(1, 5, 4, 0),
+    prodvers=(1, 5, 4, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -14,12 +14,12 @@ VSVersionInfo(
       StringTable('040904E4', [
           StringStruct('CompanyName', 'Mr5niper5oft'),
           StringStruct('FileDescription', 'Windows Audio Control CLI'),
-          StringStruct('FileVersion', '1.5.3.0'),
+          StringStruct('FileVersion', '1.5.4.0'),
           StringStruct('InternalName', 'audioctl'),
           StringStruct('LegalCopyright', 'Copyright (c) 2025 Mr5niper5oft'),
           StringStruct('OriginalFilename', 'audioctl.exe'),
           StringStruct('ProductName', 'Windows Audio Control CLI'),
-          StringStruct('ProductVersion', '1.5.3.0'),
+          StringStruct('ProductVersion', '1.5.4.0'),
         ]
       )
     ]),


### PR DESCRIPTION
## Overview
This PR updates the application to **v1.5.4.0** and shifts the "Print CLI commands" feature to a more human-readable format. Instead of echoing commands with internal GUID strings (IDs), the GUI now generates commands using device **Names** and **Indices**, making them easier for users to read and copy-paste directly into a terminal.

## Key Changes
* **GUI Mirroring Logic:** Updated `on_set_default`, `on_set_volume`, `on_toggle_mute`, and others in `audioctl/gui.py` to create a separate `display_args` list using `--name` and `--index` specifically for the console output.
* **Bug Fixes:**
    * Corrected a flag mapping error for recording devices in the `set-default` logic.
    * Removed redundant quoting in the CLI display output to ensure PowerShell compatibility.
* **Version Update:** Incremented versioning from `1.5.3.0` to `1.5.4.0` across `audioctl/gui.py`, `version.txt`, and documentation.
* **Documentation:**
    * Added [v1.5.4.0 to the CHANGELOG.md](https://github.com/Mr5niper/WindowsAudioControl-CLI-wGUI/blob/gui-print-cli-uses-name-instead-of-id/docs/CHANGELOG.md).
    * Updated the [ENGINEERING_GUIDE.md](https://github.com/Mr5niper/WindowsAudioControl-CLI-wGUI/blob/gui-print-cli-uses-name-instead-of-id/docs/ENGINEERING_GUIDE.md) to reflect the new GUI behavior.
    * Updated `README.md` with new screenshots and expanded credits.

## Verification Results
* "Print CLI" output now displays as: `.\audioctl.exe set-volume --name "Speakers" --index 0 --level 50`.
* Commands copied from the GUI console execute correctly in a standard command prompt.
* Recording device default selection now correctly maps to `--recording-name` instead of incorrectly mirroring playback flags.

## Files Changed
* `audioctl/gui.py`
* `docs/CHANGELOG.md`
* `docs/ENGINEERING_GUIDE.md`
* `docs/README.md`
* `version.txt`