### PR TITLE
Help section

### DIFF
--- a/audioctl/cli.py
+++ b/audioctl/cli.py
@@ -91,7 +91,7 @@ class AudioCtlArgumentParser(argparse.ArgumentParser):
                 if action.help is not argparse.SUPPRESS:
                     positionals.append(action)
 
-        # Positional arguments / subcommands
+        # positional arguments / commands
         if subparsers_action or positionals:
             lines.append("positional arguments:")
 
@@ -103,17 +103,17 @@ class AudioCtlArgumentParser(argparse.ArgumentParser):
                     help_map[choice_action.dest] = choice_action.help or ""
 
                 visible = []
-                for name, sp in subparsers_action.choices.items():
+                for name, _sp in subparsers_action.choices.items():
                     if name in self.HIDDEN_COMMANDS:
                         continue
                     visible.append((name, help_map.get(name, "")))
 
-                col_width = 22
+                cmd_col_width = 22
                 if visible:
-                    col_width = max(col_width, max(len(name) for name, _ in visible) + 2)
+                    cmd_col_width = max(cmd_col_width, max(len(name) for name, _ in visible) + 2)
 
                 for name, help_text in visible:
-                    lines.append(f"    {name.ljust(col_width)} {help_text}")
+                    lines.append(f"    {name.ljust(cmd_col_width)} {help_text}")
 
             for action in positionals:
                 label = action.metavar or action.dest.upper()
@@ -124,28 +124,44 @@ class AudioCtlArgumentParser(argparse.ArgumentParser):
 
             lines.append("")
 
-        # Options
+        # options
         if options:
             lines.append("options:")
 
             rows = []
             for action in options:
-                left = ", ".join(action.option_strings)
+                flags = ", ".join(action.option_strings)
 
+                metavar = ""
                 if action.nargs != 0:
                     if action.metavar:
-                        left += f" {action.metavar}"
+                        metavar = str(action.metavar)
                     elif action.dest != "help":
-                        left += f" {action.dest.upper()}"
+                        metavar = str(action.dest).upper()
 
-                rows.append((left, action.help or ""))
+                help_text = action.help or ""
+                rows.append((flags, metavar, help_text))
 
-            col_width = 26
+            flag_col_width = 24
+            meta_col_width = 16
+
             if rows:
-                col_width = max(col_width, max(len(left) for left, _ in rows) + 2)
+                flag_col_width = max(flag_col_width, max(len(flags) for flags, _, _ in rows) + 2)
+                meta_col_width = max(meta_col_width, max(len(meta) for _, meta, _ in rows) + 2)
 
-            for left, right in rows:
-                lines.append(f"  {left.ljust(col_width)} {right}")
+            for flags, metavar, help_text in rows:
+                if metavar:
+                    lines.append(
+                        f"  {flags.ljust(flag_col_width)}"
+                        f"{metavar.ljust(meta_col_width)}"
+                        f"{help_text}"
+                    )
+                else:
+                    lines.append(
+                        f"  {flags.ljust(flag_col_width)}"
+                        f"{''.ljust(meta_col_width)}"
+                        f"{help_text}"
+                    )
 
             lines.append("")
 
@@ -1299,59 +1315,70 @@ def build_parser():
     # --- list ---
     p_list = sub.add_parser("list", help="List devices")
     p_list.add_argument("--all", action="store_true", help="Include disabled/disconnected")
-    p_list.add_argument("--json", action="store_true")
+    p_list.add_argument("--json", action="store_true", help="Output device list as JSON")
     p_list.set_defaults(func=cmd_list)
     # --- set-default ---
     p_sd = sub.add_parser("set-default", help="Set default playback/recording devices (Admin might be required)")
-    p_sd.add_argument("--playback-id")
-    p_sd.add_argument("--playback-name")
-    p_sd.add_argument("--playback-role", choices=list(ROLES.keys()), default="all")
+    p_sd.add_argument("--playback-id", help="Exact device ID for the playback device")
+    p_sd.add_argument("--playback-name", help="Substring or regex of the playback device name")
+    p_sd.add_argument(
+        "--playback-role",
+        choices=list(ROLES.keys()),
+        default="all",
+        help="Role to set for playback: console, multimedia, communications, or all"
+    )
     p_sd.add_argument("--playback-flow", choices=["Render"], help=argparse.SUPPRESS)
-    p_sd.add_argument("--recording-id")
-    p_sd.add_argument("--recording-name")
-    p_sd.add_argument("--recording-role", choices=list(ROLES.keys()), default="communications")
+    p_sd.add_argument("--recording-id", help="Exact device ID for the recording device")
+    p_sd.add_argument("--recording-name", help="Substring or regex of the recording device name")
+    p_sd.add_argument(
+        "--recording-role",
+        choices=list(ROLES.keys()),
+        default="communications",
+        help="Role to set for recording: console, multimedia, communications, or all"
+    )
     p_sd.add_argument("--recording-flow", choices=["Capture"], help=argparse.SUPPRESS)
-    p_sd.add_argument("--index", type=int)
-    p_sd.add_argument("--regex", action="store_true")
+    p_sd.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_sd.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_sd.set_defaults(func=cmd_set_default)
     # --- volume/mute ---
     p_sv = sub.add_parser("set-volume", help="Set endpoint volume (render or capture) or mute/unmute")
-    p_sv.add_argument("--id")
-    p_sv.add_argument("--name")
+    p_sv.add_argument("--id", help="Exact device ID")
+    p_sv.add_argument("--name", help="Substring or regex of the device name")
     p_sv.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
     p_sv.add_argument("--level", type=int, help="0-100 (for volume)")
     p_sv.add_argument("--mute", action="store_true", help="Mute the device")
     p_sv.add_argument("--unmute", action="store_true", help="Unmute the device")
-    p_sv.add_argument("--index", type=int)
-    p_sv.add_argument("--regex", action="store_true")
+    p_sv.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_sv.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_sv.add_argument("--json", action="store_true", help="Output JSON on success (default) and minimized text on error")
     p_sv.set_defaults(func=cmd_set_volume)
     p_gv = sub.add_parser("get-volume", help="Get endpoint volume and mute state (render or capture)")
-    p_gv.add_argument("--id")
-    p_gv.add_argument("--name")
+    p_gv.add_argument("--id", help="Exact device ID")
+    p_gv.add_argument("--name", help="Substring or regex of the device name")
     p_gv.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
-    p_gv.add_argument("--index", type=int)
-    p_gv.add_argument("--regex", action="store_true")
+    p_gv.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_gv.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_gv.set_defaults(func=cmd_get_volume)
     # --- listen ---
     p_ls = sub.add_parser("listen", help="Enable/disable 'Listen to this device' (capture only)")
     p_ls.add_argument("--id", help="Device ID for the capture device.")
-    p_ls.add_argument("--name", help="Substring of the device name for the capture device.")
+    p_ls.add_argument("--name", help="Substring or regex of the capture device name")
     p_ls.add_argument("--enable", action="store_true", help="Enable 'Listen to this device'.")
     p_ls.add_argument("--disable", action="store_true", help="Disable 'Listen to this device'.")
     p_ls.add_argument("--playback-target-id", nargs='?', const='', default=None, help="Optional: Render endpoint ID to play through. Use without a value for 'Default Playback Device'.")
     p_ls.add_argument("--playback-target-name", nargs='?', const='', default=None, help="Optional: Render endpoint name to play through. Use without a value for 'Default Playback Device'.")
-    p_ls.add_argument("--index", type=int)
-    p_ls.add_argument("--regex", action="store_true")
-    p_ls.add_argument("--json", action="store_true", help="Output JSON on success (default) and minimized text on error")
+    p_ls.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_ls.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
+    p_ls.add_argument("--json", action="store_true", help="Output JSON on success (default) and minimized text on error")  
     p_ls.set_defaults(func=cmd_listen)
+    # --- get-listen ---  
     p_gl = sub.add_parser("get-listen", help="Get 'Listen to this device' enabled/disabled state for a capture device")
-    p_gl.add_argument("--id", help="Device ID for the capture device.")
-    p_gl.add_argument("--name", help="Substring or regex of the device name")
-    p_gl.add_argument("--index", type=int)
-    p_gl.add_argument("--regex", action="store_true")
-    p_gl.add_argument("--playback-target-id", nargs='?', const='', help="Request current playback routing target ID")
-    p_gl.add_argument("--playback-target-name", nargs='?', const='', help="Request current playback routing target name")
+    p_gl.add_argument("--id", help="Exact device ID for the capture device")
+    p_gl.add_argument("--name", help="Substring or regex of the capture device name")
+    p_gl.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_gl.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
+    p_gl.add_argument("--playback-target-id", nargs='?', const='', help="Also report the current playback routing target ID")
+    p_gl.add_argument("--playback-target-name", nargs='?', const='', help="Also report the current playback routing target name")
     p_gl.set_defaults(func=cmd_get_listen)
     # --- enhancements / FX subsystem ---
     p_fx = sub.add_parser("enhancements", help="Enable/disable 'Audio Enhancements' (SysFX) on a device")
@@ -1361,7 +1388,7 @@ def build_parser():
     p_fx.add_argument("--enable", action="store_true", help="Enable audio enhancements")
     p_fx.add_argument("--disable", action="store_true", help="Disable audio enhancements")
     p_fx.add_argument("--index", type=int, help="GUI-order index among matches")
-    p_fx.add_argument("--regex", action="store_true")
+    p_fx.add_argument("--regex", action="store_true", help="Treat name or FX filters as regular expressions")
     p_fx.add_argument("--prefer-hklm", action="store_true",
                       help="For learned INI toggles that write registry values, prefer HKLM ordering (Admin typically required).")
     p_fx.add_argument("--vendor-ini", help="Path to vendor_toggles.ini (default: next to the EXE).")
@@ -1386,21 +1413,21 @@ def build_parser():
         "get-enhancements",
         help="Get current enhancements enabled/disabled state for a device (vendor-only)"
     )
-    p_ge.add_argument("--id")
-    p_ge.add_argument("--name")
-    p_ge.add_argument("--flow", choices=["Render", "Capture"])
-    p_ge.add_argument("--index", type=int)
-    p_ge.add_argument("--regex", action="store_true")
+    p_ge.add_argument("--id", help="Exact device ID")
+    p_ge.add_argument("--name", help="Substring or regex of the device name")
+    p_ge.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_ge.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_ge.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_ge.set_defaults(func=cmd_get_enhancements)
     p_gds = sub.add_parser(
         "get-device-state",
         help="Get current state for a device (volume, mute, listen, enhancements, FX) for GUI"
     )
-    p_gds.add_argument("--id")
-    p_gds.add_argument("--name")
-    p_gds.add_argument("--flow", choices=["Render", "Capture"])
-    p_gds.add_argument("--index", type=int)
-    p_gds.add_argument("--regex", action="store_true")
+    p_gds.add_argument("--id", help="Exact device ID")
+    p_gds.add_argument("--name", help="Substring or regex of the device name")
+    p_gds.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_gds.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_gds.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_gds.add_argument("--vendor-ini", help="Optional vendor INI path for FX lookup")
     p_gds.set_defaults(func=cmd_get_device_state)
     # --- diagnostics ---
@@ -1408,37 +1435,37 @@ def build_parser():
         "diag-sysfx",
         help="Dump live Enhancements state (COM, PropertyStore, vendor toggles)"
     )
-    p_dx.add_argument("--id")
-    p_dx.add_argument("--name")
-    p_dx.add_argument("--flow", choices=["Render", "Capture"])
-    p_dx.add_argument("--index", type=int)
-    p_dx.add_argument("--regex", action="store_true")
+    p_dx.add_argument("--id", help="Exact device ID")
+    p_dx.add_argument("--name", help="Substring or regex of the device name")
+    p_dx.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_dx.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_dx.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_dx.set_defaults(func=cmd_diag_sysfx)
     p_dm = sub.add_parser("diag-mmdevices", help="Dump all MMDevices values for an endpoint (debug)")
-    p_dm.add_argument("--id")
-    p_dm.add_argument("--name")
-    p_dm.add_argument("--flow", choices=["Render", "Capture"])
-    p_dm.add_argument("--index", type=int)
-    p_dm.add_argument("--regex", action="store_true")
+    p_dm.add_argument("--id", help="Exact device ID")
+    p_dm.add_argument("--name", help="Substring or regex of the device name")
+    p_dm.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_dm.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_dm.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_dm.set_defaults(func=cmd_diag_mmdevices)
     # --- discovery (interactive report generation) ---
     p_learn = sub.add_parser("discover-enhancements", help="Interactively learn how Enhancements toggles for a device")
-    p_learn.add_argument("--id")
-    p_learn.add_argument("--name")
-    p_learn.add_argument("--flow", choices=["Render", "Capture"])
-    p_learn.add_argument("--index", type=int)
-    p_learn.add_argument("--regex", action="store_true")
+    p_learn.add_argument("--id", help="Exact device ID")
+    p_learn.add_argument("--name", help="Substring or regex of the device name")
+    p_learn.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_learn.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_learn.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_learn.add_argument("--output-dir", help="Where to write the TXT/JSON report (default: current directory)")
     p_learn.add_argument("--ini-snippet", help="Write a suggested vendor INI section to this path (append).")
     p_learn.set_defaults(func=cmd_discover_enhancements)
     # --- wait ---
     p_w = sub.add_parser("wait", help="Wait for device to appear")
-    p_w.add_argument("--id")
-    p_w.add_argument("--name")
-    p_w.add_argument("--flow", choices=["Render", "Capture"])
-    p_w.add_argument("--timeout", type=int, default=30)
-    p_w.add_argument("--index", type=int)
-    p_w.add_argument("--regex", action="store_true")
+    p_w.add_argument("--id", help="Exact device ID")
+    p_w.add_argument("--name", help="Substring or regex of the device name")
+    p_w.add_argument("--flow", choices=["Render", "Capture"], help="Optional filter to disambiguate")
+    p_w.add_argument("--timeout", type=int, default=30, help="Seconds to wait before timing out")
+    p_w.add_argument("--index", type=int, help="GUI-order index among matches")
+    p_w.add_argument("--regex", action="store_true", help="Treat name filters as regular expressions")
     p_w.set_defaults(func=cmd_wait)
     # Hidden helper: elevated INI append (used by GUI to write into Program Files)
     # The GUI can write a "work order" JSON file and then run this subcommand via

--- a/audioctl/cli.py
+++ b/audioctl/cli.py
@@ -67,6 +67,90 @@ from .vendor_db import (
     _fast_read_vendor_entry_state,
 )
 
+class AudioCtlArgumentParser(argparse.ArgumentParser):
+    HIDDEN_COMMANDS = {"vendor-ini-append"}
+
+    def format_help(self):
+        lines = []
+
+        title = self.description or "Windows Audio Control CLI"
+        lines.append(title)
+        lines.append("")
+
+        positionals = []
+        options = []
+        subparsers_action = None
+
+        for action in self._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                subparsers_action = action
+            elif action.option_strings:
+                if action.help is not argparse.SUPPRESS:
+                    options.append(action)
+            else:
+                if action.help is not argparse.SUPPRESS:
+                    positionals.append(action)
+
+        # Positional arguments / subcommands
+        if subparsers_action or positionals:
+            lines.append("positional arguments:")
+
+            if subparsers_action:
+                lines.append("  COMMAND")
+
+                help_map = {}
+                for choice_action in getattr(subparsers_action, "_choices_actions", []):
+                    help_map[choice_action.dest] = choice_action.help or ""
+
+                visible = []
+                for name, sp in subparsers_action.choices.items():
+                    if name in self.HIDDEN_COMMANDS:
+                        continue
+                    visible.append((name, help_map.get(name, "")))
+
+                col_width = 22
+                if visible:
+                    col_width = max(col_width, max(len(name) for name, _ in visible) + 2)
+
+                for name, help_text in visible:
+                    lines.append(f"    {name.ljust(col_width)} {help_text}")
+
+            for action in positionals:
+                label = action.metavar or action.dest.upper()
+                help_text = action.help or ""
+                lines.append(f"  {label}")
+                if help_text:
+                    lines.append(f"    {help_text}")
+
+            lines.append("")
+
+        # Options
+        if options:
+            lines.append("options:")
+
+            rows = []
+            for action in options:
+                left = ", ".join(action.option_strings)
+
+                if action.nargs != 0:
+                    if action.metavar:
+                        left += f" {action.metavar}"
+                    elif action.dest != "help":
+                        left += f" {action.dest.upper()}"
+
+                rows.append((left, action.help or ""))
+
+            col_width = 26
+            if rows:
+                col_width = max(col_width, max(len(left) for left, _ in rows) + 2)
+
+            for left, right in rows:
+                lines.append(f"  {left.ljust(col_width)} {right}")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
 def _resolve_standard_target(args, flow_forced=None):
     """
     Standard logic to find a SINGLE target device while respecting global GUI indices.
@@ -1202,8 +1286,16 @@ def build_parser():
     #   - Enhancements vendor control + FX subsystem (enhancements, get-enhancements, get-device-state)
     #   - diagnostics and discovery (diag-sysfx, diag-mmdevices, discover-enhancements)
     #   - internal helper for elevation (vendor-ini-append)
-    p = argparse.ArgumentParser(prog="audioctl", description="Windows audio control CLI (pycaw-based)")
-    sub = p.add_subparsers(dest="cmd", required=True)
+    p = AudioCtlArgumentParser(
+        prog="audioctl",
+        description="Windows Audio Control CLI"
+    )
+    sub = p.add_subparsers(
+        dest="cmd",
+        required=True,
+        metavar="COMMAND",
+        parser_class=AudioCtlArgumentParser
+    )
     # --- list ---
     p_list = sub.add_parser("list", help="List devices")
     p_list.add_argument("--all", action="store_true", help="Include disabled/disconnected")

--- a/audioctl/gui.py
+++ b/audioctl/gui.py
@@ -419,7 +419,7 @@ def run_audioctl_interactive(args_list, prompt_patterns, expect_ok=True):
 class AudioGUI:
     def __init__(self, root):
         self.root = root
-        self.root.title("Mr5niper's Audio Control  v1.5.4.0  04-29-2026")
+        self.root.title("Mr5niper's Audio Control  v1.5.4.1  05-09-2026")
         # Style and theme
         style = ttk.Style(self.root)
         try:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # AUDIOCTL.PY CHANGELOG
-## v1.5.4.0 - [current]
+## v1.5.4.1 - [current]
+### CLI Help & UX
+- **Unified Help Formatting:** Reworked CLI help output to use a cleaner, more readable layout across the root command and all subcommands.
+  - Replaced the default argparse `{cmd1,cmd2,...}` display with a simplified `COMMAND` listing.
+  - Standardized section spacing and alignment for improved readability.
+  - Widened the first column so command names and option flags line up more cleanly.
+
+- **Hidden Internal Helper Command:** Removed the internal `vendor-ini-append` helper from user-facing help output.
+  - This command remains available internally for GUI/elevated workflows.
+  - Prevents the helper from appearing as if it were a supported public command.
+
+### Fixes
+- **Ghost Command Help Output:** Fixed the issue where `audioctl -h` displayed the internal `vendor-ini-append` helper in the public subcommand list.
+- **Argparse Suppression Artifact:** Eliminated the confusing `==SUPPRESS==` text that appeared beside the hidden internal helper in help output.
+- **Consistent Help Presentation:** Help output now uses the same cleaner listing style and spacing throughout the CLI.
+
+---
+
+## v1.5.4.0
 
 ### GUI & CLI Mirroring
 Friendly Command Echoing: Updated the "Print CLI commands" feature to use device Names and Indices (matching the GUI list order) instead of internal GUID strings. This ensures echoed commands are human-readable and can be copy-pasted directly into a terminal.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,16 +4,25 @@
 - **Unified Help Formatting:** Reworked CLI help output to use a cleaner, more readable layout across the root command and all subcommands.
   - Replaced the default argparse `{cmd1,cmd2,...}` display with a simplified `COMMAND` listing.
   - Standardized section spacing and alignment for improved readability.
-  - Widened the first column so command names and option flags line up more cleanly.
+  - Applied the same custom help style to both the root parser and all subcommands [1].
+
+- **Aligned Multi-Column Help Output:** Improved option formatting so help output is easier to scan.
+  - Split option help into aligned columns for flags, metavar/example values, and descriptions.
+  - Widened help columns so command names, option flags, and metavars line up more cleanly.
+
+- **Complete Public Argument Descriptions:** Added missing help text for public CLI arguments so help sections no longer show blank description fields.
+  - Improved consistency across subcommand help screens.
+  - Keeps public command help self-documenting and easier to understand [1].
 
 - **Hidden Internal Helper Command:** Removed the internal `vendor-ini-append` helper from user-facing help output.
   - This command remains available internally for GUI/elevated workflows.
-  - Prevents the helper from appearing as if it were a supported public command.
+  - Prevents the helper from appearing as if it were a supported public command [1][2].
 
 ### Fixes
-- **Ghost Command Help Output:** Fixed the issue where `audioctl -h` displayed the internal `vendor-ini-append` helper in the public subcommand list.
-- **Argparse Suppression Artifact:** Eliminated the confusing `==SUPPRESS==` text that appeared beside the hidden internal helper in help output.
-- **Consistent Help Presentation:** Help output now uses the same cleaner listing style and spacing throughout the CLI.
+- **Ghost Command Help Output:** Fixed the issue where `audioctl -h` displayed the internal `vendor-ini-append` helper in the public subcommand list [1].
+- **Argparse Suppression Artifact:** Eliminated the confusing `==SUPPRESS==` text that appeared beside the hidden internal helper in help output [1].
+- **Blank Help Descriptions:** Fixed missing parser help text that caused some public options to render with empty description columns in subcommand help [1].
+- **Consistent Help Presentation:** Help output now uses the same cleaner listing style, spacing, and alignment throughout the CLI [1].
 
 ---
 

--- a/docs/ENGINEERING_GUIDE.md
+++ b/docs/ENGINEERING_GUIDE.md
@@ -1,8 +1,8 @@
-# ENGINEERING GUIDE (v1.5.4.0)
+# ENGINEERING GUIDE (v1.5.4.1)
 **audioctl - Windows Audio Control CLI + GUI (PyInstaller EXE)**
 **Audience:** Engineers debugging, maintaining, or extending the codebase  
 **Platforms:** Windows 10/11  
-**Version:** 1.5.4.0 
+**Version:** 1.5.4.1 
 **Build contract:** **Python 3.13.12 required**, **PyInstaller required**
 
 This document is intentionally **not** a usage manual. The README covers commands, examples, and screenshots.  
@@ -36,7 +36,7 @@ The *real* entrypoint is always:
 - `audioctl.cli.main()`
 
 ### 1.4 Build artifacts / metadata
-- Windows version info comes from version.txt (filevers/prodvers 1.5.4.0).
+- Windows version info comes from version.txt (filevers/prodvers 1.5.4.1).
 - Icon `audio.ico` is embedded and also shipped as data.
 
 ---

--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(1, 5, 4, 0),
-    prodvers=(1, 5, 4, 0),
+    filevers=(1, 5, 4, 1),
+    prodvers=(1, 5, 4, 1),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -14,12 +14,12 @@ VSVersionInfo(
       StringTable('040904E4', [
           StringStruct('CompanyName', 'Mr5niper5oft'),
           StringStruct('FileDescription', 'Windows Audio Control CLI'),
-          StringStruct('FileVersion', '1.5.4.0'),
+          StringStruct('FileVersion', '1.5.4.1'),
           StringStruct('InternalName', 'audioctl'),
           StringStruct('LegalCopyright', 'Copyright (c) 2025 Mr5niper5oft'),
           StringStruct('OriginalFilename', 'audioctl.exe'),
           StringStruct('ProductName', 'Windows Audio Control CLI'),
-          StringStruct('ProductVersion', '1.5.4.0'),
+          StringStruct('ProductVersion', '1.5.4.1'),
         ]
       )
     ]),


### PR DESCRIPTION
This PR merges the help-section branch into main, officially incrementing the project to v1.5.4.1. The primary focus of this update is a complete overhaul of the CLI help system to improve readability and hide internal-only commands.

Key Updates:
Unified Help Formatting: Replaced the default argparse layout with a cleaner, custom-aligned output for the root command and all subcommands.

Hidden Internal Helpers: The vendor-ini-append command is now hidden from the public help list to prevent confusion, while remaining functional for GUI elevation tasks.

Standardized Alignment: Improved multi-column alignment for flags, metavars, and descriptions, making the CLI much easier to scan.

Documentation Completion: Added missing help= strings for several public arguments that were previously showing as blank.

Version Bump: Updated audioctl/gui.py, docs/CHANGELOG.md, docs/ENGINEERING_GUIDE.md, and version.txt to reflect v1.5.4.1.

Files Changed:
audioctl/cli.py: Implemented AudioCtlArgumentParser for custom help logic.

audioctl/gui.py: Updated window title and version string.

docs/CHANGELOG.md: Added detailed notes for the 1.5.4.1 release.

docs/ENGINEERING_GUIDE.md & version.txt: Incremented version metadata.